### PR TITLE
Add option to specify remote NameServer to query

### DIFF
--- a/lp-ddns/etc/lp-dyndns/settings.conf
+++ b/lp-ddns/etc/lp-dyndns/settings.conf
@@ -2,10 +2,11 @@
 # RECORDID="235890
 # PASSWORD="verystrongpassword"
 # DOMAIN="sub.domain.tld"
-
+# NAMESERVER="NameServerToQuery"
 
 
 
 RECORDID=""
 PASSWORD=""
 DOMAIN=""
+NAMESERVER="" #Blank for system NameServer

--- a/lp-ddns/usr/local/bin/lp-ddns
+++ b/lp-ddns/usr/local/bin/lp-ddns
@@ -14,7 +14,12 @@ set -e
 
 IP="$(curl --connect-timeout 10 -s ipv4.is || curl --connect-timeout 10 -s ipv4.is)"
 #IP="$(curl --config /etc/lp-dyndns/curlrc)"
-CURRENTIP="$(dig ${DOMAIN} +short)"
+if [ "${NAMESERVER}" = "" ];
+then
+	CURRENTIP="$(dig ${DOMAIN} +short)"
+else
+	CURRENTIP="$(dig @${NAMESERVER} ${DOMAIN} +short)"
+fi
 APIURL="https://freedns.linux.pizza/api/v1/remote/updatepw?record=${RECORDID}&password=${PASSWORD}&content=${IP}"
 # Making stuff fancy
 NC='\033[0m' 


### PR DESCRIPTION
This helps in the case that the NameServer on the
system running lp-ddns uses a local NameServer and
resolves to local IP for the domain in question.

Signed-off-by: Marc Grondin <myself@marcg.pizza>